### PR TITLE
Bump dependencies to use Studio 4.0 and use  View Binding 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,10 @@ android {
         }
     }
 
+    buildFeatures {
+        viewBinding = true
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,10 +37,10 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.2.0'
+    implementation 'androidx.core:core-ktx:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.0.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "androidx.navigation:navigation-dynamic-features-fragment:$nav_version"

--- a/app/src/main/java/io/github/prabhuomkar/torchexpo/MainActivity.kt
+++ b/app/src/main/java/io/github/prabhuomkar/torchexpo/MainActivity.kt
@@ -1,5 +1,7 @@
 package io.github.prabhuomkar.torchexpo
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
@@ -32,9 +34,16 @@ class MainActivity : AppCompatActivity() {
         return super.onCreateOptionsMenu(menu)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        val navController = findNavController(R.id.nav_host_fragment)
-        return item.onNavDestinationSelected(navController) || super.onOptionsItemSelected(item)
+    override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
+        R.id.aboutFragment -> {
+            item.onNavDestinationSelected(findNavController(R.id.nav_host_fragment))
+            true
+        }
+        R.id.action_help -> {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/prabhuomkar/TorchExpo")))
+            true
+        }
+        else -> super.onOptionsItemSelected(item)
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/java/io/github/prabhuomkar/torchexpo/MainActivity.kt
+++ b/app/src/main/java/io/github/prabhuomkar/torchexpo/MainActivity.kt
@@ -4,13 +4,12 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.onNavDestinationSelected
 import androidx.navigation.ui.setupActionBarWithNavController
-import io.github.prabhuomkar.torchexpo.ui.main.MainFragment
-import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
 

--- a/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/about/AboutFragment.kt
+++ b/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/about/AboutFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
 import io.github.prabhuomkar.torchexpo.BuildConfig
+import io.github.prabhuomkar.torchexpo.R
 import io.github.prabhuomkar.torchexpo.databinding.AboutFragmentBinding
 
 class AboutFragment : Fragment() {
@@ -31,7 +32,7 @@ class AboutFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.versionTextView.text = "v${BuildConfig.VERSION_NAME}"
+        binding.versionTextView.text = requireContext().getString(R.string.app_version, BuildConfig.VERSION_NAME)
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/about/AboutFragment.kt
+++ b/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/about/AboutFragment.kt
@@ -4,11 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
 import io.github.prabhuomkar.torchexpo.BuildConfig
-import io.github.prabhuomkar.torchexpo.R
+import io.github.prabhuomkar.torchexpo.databinding.AboutFragmentBinding
 
 class AboutFragment : Fragment() {
 
@@ -18,17 +17,21 @@ class AboutFragment : Fragment() {
     }
 
     private lateinit var viewModel: AboutViewModel
-    private lateinit var versionTextView: TextView
+    private var _binding: AboutFragmentBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val view: View = inflater.inflate(R.layout.about_fragment, container, false)
-        versionTextView = view.findViewById<TextView>(R.id.versionTextView)
-        versionTextView.text = "v${BuildConfig.VERSION_NAME}"
-        return view
+        _binding = AboutFragmentBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.versionTextView.text = "v${BuildConfig.VERSION_NAME}"
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/about/AboutFragment.kt
+++ b/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/about/AboutFragment.kt
@@ -1,16 +1,14 @@
 package io.github.prabhuomkar.torchexpo.ui.about
 
-import android.content.pm.PackageInfo
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProviders
 import io.github.prabhuomkar.torchexpo.BuildConfig
 import io.github.prabhuomkar.torchexpo.R
-
 
 class AboutFragment : Fragment() {
 
@@ -23,7 +21,8 @@ class AboutFragment : Fragment() {
     private lateinit var versionTextView: TextView
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         val view: View = inflater.inflate(R.layout.about_fragment, container, false)
@@ -37,5 +36,4 @@ class AboutFragment : Fragment() {
         viewModel = ViewModelProviders.of(this).get(AboutViewModel::class.java)
         // TODO: Use the ViewModel
     }
-
 }

--- a/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/about/AboutFragment.kt
+++ b/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/about/AboutFragment.kt
@@ -40,4 +40,9 @@ class AboutFragment : Fragment() {
         viewModel = ViewModelProviders.of(this).get(AboutViewModel::class.java)
         // TODO: Use the ViewModel
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/main/MainFragment.kt
+++ b/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/main/MainFragment.kt
@@ -32,4 +32,9 @@ class MainFragment : Fragment() {
         viewModel = ViewModelProviders.of(this).get(MainViewModel::class.java)
         // TODO: Use the ViewModel
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/main/MainFragment.kt
+++ b/app/src/main/java/io/github/prabhuomkar/torchexpo/ui/main/MainFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
-import io.github.prabhuomkar.torchexpo.R
+import io.github.prabhuomkar.torchexpo.databinding.MainFragmentBinding
 
 class MainFragment : Fragment() {
 
@@ -15,13 +15,16 @@ class MainFragment : Fragment() {
     }
 
     private lateinit var viewModel: MainViewModel
+    private var _binding: MainFragmentBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        return inflater.inflate(R.layout.main_fragment, container, false)
+        _binding = MainFragmentBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/app/src/main/res/menu/options_menu.xml
+++ b/app/src/main/res/menu/options_menu.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@id/aboutFragment"
         android:title="@string/options_menu_about"
-        />
+        app:showAsAction="never"/>
+    <item
+        android:id="@+id/action_help"
+        android:title="@string/options_menu_github"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="app_description">Collection of machine learning experiments using PyTorch Android API</string>
     <string name="placeholder_version">v1.1</string>
     <string name="logo_content_description">App Logo</string>
+    <string name="app_version">v%1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="placeholder_version">v1.1</string>
     <string name="logo_content_description">App Logo</string>
     <string name="app_version">v%1$s</string>
+    <string name="options_menu_github">Github</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.3.72'
     ext.nav_version = "2.3.0-beta01"
     ext.mat_comp_version = '1.1.0'
     repositories {
@@ -11,7 +11,7 @@ buildscript {
     }
     dependencies {
 
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat May 30 22:06:25 IST 2020
+#Tue Jun 02 23:23:21 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
* Studio 4.0 is the latest stable android studio release, increase android gradle plugin version to be compatible with it 
* Use view binding to replace findViewById calls. Viewbinding is both type safe and null safe providing compile time safety.
* Move logic that operates on the view to onViewCreated according to [documentation](https://developer.android.com/reference/kotlin/androidx/fragment/app/Fragment?hl=en#onCreateView(android.view.LayoutInflater,%20android.view.ViewGroup,%20android.os.Bundle))
* Use placeholder string resources rather than concatenating strings together